### PR TITLE
Minor correction to dockerUpdateApps.page

### DIFF
--- a/source/ca.update.applications/usr/local/emhttp/plugins/ca.update.applications/dockerUpdateApps.page
+++ b/source/ca.update.applications/usr/local/emhttp/plugins/ca.update.applications/dockerUpdateApps.page
@@ -180,7 +180,7 @@ function toggleAll() {
     <option value='no'><?tr("No");?></option>
     </select></td>
 </tr>
-<tr><td><strong><?tr("Update Check Frequency:")?></strong><br><?tr("Do not overlap with autoupdate");?></td>
+<tr><td><strong><?tr("Update Check Frequency:")?></strong><br><?tr("Do not overlap with a backup schedule");?></td>
 <td><select id='dockerCronFrequency' class='dockerCron'>
   <option value='disabled'><?tr("Disabled");?></option>
   <option value='Daily'><?tr("Daily");?></option>


### PR DESCRIPTION
According to [this comment](https://forums.unraid.net/topic/51959-plugin-ca-application-auto-update/?do=findComment&comment=1097341), this line should read "Do not overlap with a backup schedule" instead of the current "Do not overlap with autoupdate".